### PR TITLE
Asset requests optimisation

### DIFF
--- a/zou/app/services/assets_service.py
+++ b/zou/app/services/assets_service.py
@@ -248,6 +248,15 @@ def get_assets_and_tasks(criterions={}, page=1, with_episode_ids=False):
             episode_links_query = episode_links_query.filter(
                 Episode.project_id == criterions["project_id"]
             )
+        if "episode_id" in criterions:
+            episode_links_query = episode_links_query.filter(
+                EntityLink.entity_in_id == criterions["episode_id"]
+            )
+        if "id" in criterions:
+            episode_links_query = episode_links_query.filter(
+                EntityLink.entity_out_id == criterions["id"]
+            )
+
         for link in episode_links_query.all():
             if str(link.entity_out_id) not in cast_in_episode_ids:
                 cast_in_episode_ids[str(link.entity_out_id)] = []


### PR DESCRIPTION
**Problem**
As the project grows, requests made on assets gets slower. We are working on a daily show wich currently has over 600 episodes stored on kitsu. We realised that the `assets` and `asset` pages got a lot slower where the `shot` and `shots` pages didn't.
- Single shot request ≈ 63.40 ms
- Single asset request ≈ 4.11 s
- Episode's shots request ≈ 22.21 ms
- Episode's assets request ≈ 4.15 s

Fetching all the assets of an episode is not particularly slower than fetching a single asset. The solution could certainly be solved by archiving unused episodes but there is still clearly an issue in the assets request.

The issue is in `get_assets_and_tasks()` from the `assets_service` module. The function resolves the EntityLinks of the episodes where the queried assets are casted. However the SQL request fetch all of the existing EntityLinks from the database that link any asset to any episodes (in our case this represent around 86000 entries) and then all the unwanted EntityLinks are filtered out via python wich is not made for looping over such large data.

**Solution**
The real solution would be to make a nested sql query to get all the assets data in a single sql request. However this involves a complete rewrite of the `get_assets_and_tasks()` function.
A simpler solution is to just use the `critirions` to filter out as much EntityLinks as possible in the sql query to reduce the work on the python side.

After this optimisation we get down to the same request time between the shots and assets reardless of the amounts of assets in the project.